### PR TITLE
fix: when removedFiles is empty when MergeResetting, skip worktreereset

### DIFF
--- a/worktree.go
+++ b/worktree.go
@@ -316,8 +316,14 @@ func (w *Worktree) ResetSparsely(opts *ResetOptions, dirs []string) error {
 		}
 	}
 
-	if opts.Mode == MergeReset || opts.Mode == HardReset {
+	if opts.Mode == MergeReset && len(removedFiles) > 0 {
 		if err := w.resetWorktree(t, removedFiles); err != nil {
+			return err
+		}
+	}
+
+	if opts.Mode == HardReset {
+		if err := w.resetWorktree(t, opts.Files); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
When the removedFiles returned by resetIndex is empty, skip running the worktreereset, because no file has to be checkedout.

But when HardResetting do run the worktreeReset with the files list in the ResetOptions, because then also untracked and ignored files need to be checkedOut.